### PR TITLE
Convert activity metric to be messages-per-user

### DIFF
--- a/main.py
+++ b/main.py
@@ -668,7 +668,7 @@ async def auto_slowmode(message):
     if time.time() >= OMEGA.last_updated + OMEGA.slowmode_check_frequency:
         delay = get_delay(OMEGA.message_cache, len(OMEGA.user_cache))
         await OMEGA.get_channel(290695292964306948).edit(slowmode_delay=delay)
-        OMEGA.message_cache = 1
+        OMEGA.message_cache = 0
         OMEGA.user_cache = set()
         OMEGA.last_updated = time.time()
     if message.channel.id != 290695292964306948:

--- a/main.py
+++ b/main.py
@@ -666,7 +666,7 @@ async def report_mode(reaction, user):
 @OMEGA.listen("on_message")
 async def auto_slowmode(message):
     if time.time() >= OMEGA.last_updated + OMEGA.slowmode_check_frequency:
-        delay = get_delay(OMEGA.message_cache)
+        delay = get_delay(OMEGA.message_cache, len(OMEGA.user_cache))
         await OMEGA.get_channel(290695292964306948).edit(slowmode_delay=delay)
         OMEGA.message_cache = 1
         OMEGA.user_cache = set()
@@ -677,9 +677,9 @@ async def auto_slowmode(message):
     OMEGA.user_cache.add(message.author)
 
 
-def get_delay(message_count):
+def get_delay(message_count, distinct_user_count):
     for limit in OMEGA.slowmode_time_configs:
-        if message_count >= limit:
+        if message_count / distinct_user_count >= limit:
             return OMEGA.slowmode_time_configs[limit]
     return 0
 

--- a/main.py
+++ b/main.py
@@ -59,6 +59,7 @@ OMEGA.slowmode_time_configs = {
     15: 5
 }
 OMEGA.message_cache = 0
+OMEGA.user_cache = set()
 OMEGA.last_updated = 0
 
 
@@ -668,10 +669,12 @@ async def auto_slowmode(message):
         delay = get_delay(OMEGA.message_cache)
         await OMEGA.get_channel(290695292964306948).edit(slowmode_delay=delay)
         OMEGA.message_cache = 1
+        OMEGA.user_cache = set()
         OMEGA.last_updated = time.time()
     if message.channel.id != 290695292964306948:
         return
     OMEGA.message_cache += 1
+    OMEGA.user_cache.add(message.author)
 
 
 def get_delay(message_count):


### PR DESCRIPTION
The idea is that the activity metric, when scaled by uesrs, better reflects the notion of "how much time are people spending between posts." Previously, even if everyone is spending time being thoughtful, many participants posting has the effect of driving up the activity score.

There's also a bug fix for how `message_cache` is counted following the start of a new update period.